### PR TITLE
[OneBot] fix group permission string in get_group_member_info

### DIFF
--- a/Lagrange.OneBot/Core/Operation/Info/GetGroupMemberInfoOperation.cs
+++ b/Lagrange.OneBot/Core/Operation/Info/GetGroupMemberInfoOperation.cs
@@ -20,7 +20,7 @@ public class GetGroupMemberInfoOperation : IOperation
                 ? new OneBotResult(null, -1, "failed") 
                 : new OneBotResult(new OneBotGroupMember(message.GroupId, 
                     result.Uin,
-                    result.Permission.ToString(), 
+                    result.Permission.ToString().ToLower(), 
                     result.GroupLevel.ToString(), result.MemberCard, result.MemberName, 
                     (uint)new DateTimeOffset(result.JoinTime).ToUnixTimeMilliseconds(), 
                     (uint)new DateTimeOffset(result.LastMsgTime).ToUnixTimeMilliseconds()), 


### PR DESCRIPTION
这个玩意应该是小写,算个typo?
![image](https://github.com/LagrangeDev/Lagrange.Core/assets/97760035/038a0127-8efd-455d-a6fc-adb448980251)
