### PR TITLE
Fix QrCode display anomaly in terminals that don't support colors

### DIFF
--- a/Lagrange.OneBot/Utility/QrCodeHelper.cs
+++ b/Lagrange.OneBot/Utility/QrCodeHelper.cs
@@ -4,27 +4,36 @@ namespace Lagrange.OneBot.Utility;
 
 internal static class QrCodeHelper
 {
+    // This part of the code is from "https://github.com/eric2788/Lagrange.Core/blob/fd20a5aec81cacd56d60f3130cf057461300fd3f/Lagrange.OneBot/Utility/QrCodeHelper.cs#L30C52-L30C52"
+    // Thanks to "https://github.com/eric2788"
     internal static void Output(string text)
     {
-        var qrCode = QrCode.EncodeText(text, QrCode.Ecc.Low);
-        
+        var segments = QrSegment.MakeSegments(text);
+        var qrCode = QrCode.EncodeSegments(segments, QrCode.Ecc.Low);
+
         for (var y = 0; y < qrCode.Size + 2; y += 2)
         {
             for (var x = 0; x < qrCode.Size + 2; ++x)
             {
-                Console.ForegroundColor = qrCode.GetModule(x - 1, y - 1)
-                    ? ConsoleColor.Black
-                    : ConsoleColor.White;
+                var foregroundBlack = qrCode.GetModule(x - 1, y - 1);
+                var backgroundBlack = qrCode.GetModule(x - 1, y) || y > qrCode.Size;
 
-                Console.BackgroundColor = qrCode.GetModule(x - 1, y) || y > qrCode.Size
-                    ? ConsoleColor.Black
-                    : ConsoleColor.White;
+                if (foregroundBlack && !backgroundBlack)
+                {
+                    Console.Write("▄");
+                } else if (!foregroundBlack && backgroundBlack)
+                {
+                    Console.Write("▀");
+                } else if (foregroundBlack && backgroundBlack)
+                {
+                    Console.Write(" ");
 
-                Console.Write("▀");
+                } else if (!foregroundBlack && !backgroundBlack)
+                {
+                    Console.Write("█");
+                }
             }
             Console.Write("\n");
         }
-        
-        Console.ResetColor();
     }
 }


### PR DESCRIPTION
修复了 QrCode 在不支持颜色的终端中显示异常的情况

其实是将 https://github.com/eric2788/Lagrange.Core/blob/fd20a5aec81cacd56d60f3130cf057461300fd3f/Lagrange.OneBot/Utility/QrCodeHelper.cs#L30C52-L30C52 的代码 Copy 了一下

原作者表示更改太多了不好 pr

感谢 [@eric2788](https://github.com/eric2788)