### PR TITLE
Added Docker Support

### DIFF
--- a/.github/workflows/Lagrange.OneBot-docker-push.yml
+++ b/.github/workflows/Lagrange.OneBot-docker-push.yml
@@ -1,0 +1,49 @@
+name: Lagrange.OneBot Docker Push
+
+on:
+  push:
+      tags:
+        - '*'
+      branches:
+        - 'master'
+      paths:
+        - "**.cs"
+        - "Dockerfile"
+        - "**.csproj"
+        - "appsettings.onebot.json"
+  workflow_dispatch:
+
+jobs:
+  build_push:
+     runs-on: ubuntu-latest
+     steps:
+      - uses: actions/checkout@v4
+      - name: Set up QEMU
+        uses: docker/setup-qemu-action@v3
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+      - name: Login to DockerHub
+        uses: docker/login-action@v3
+        with:
+          username: ${{ secrets.DOCKER_USERNAME }}
+          password: ${{ secrets.DOCKER_PASSWORD }}
+      - name: Extract metadata (tags, labels) for Docker
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: |
+            docker.io/${{ secrets.DOCKER_USERNAME }}/lagrange.onebot
+          tags: |
+            type=edge
+            type=sha,event=branch
+            type=ref,event=tag
+      - name: Build and push
+        id: docker_build
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          platforms: linux/arm64/v8, linux/amd64
+

--- a/.github/workflows/Lagrange.OneBot-docker-push.yml
+++ b/.github/workflows/Lagrange.OneBot-docker-push.yml
@@ -30,7 +30,7 @@ jobs:
         with:
           registry: ghcr.io
           username: ${{ github.repository_owner }}
-          password: ${{ secrets.GITHUB_TOKEN }}
+          password: ${{ secrets.GIT_TOKEN }}
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5

--- a/.github/workflows/Lagrange.OneBot-docker-push.yml
+++ b/.github/workflows/Lagrange.OneBot-docker-push.yml
@@ -16,23 +16,27 @@ on:
 jobs:
   build_push:
      runs-on: ubuntu-latest
+     permissions:
+        contents: read
+        packages: write
      steps:
       - uses: actions/checkout@v4
       - name: Set up QEMU
         uses: docker/setup-qemu-action@v3
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v3
-      - name: Login to DockerHub
+      - name: Login to Github Registry
         uses: docker/login-action@v3
         with:
-          username: ${{ secrets.DOCKER_USERNAME }}
-          password: ${{ secrets.DOCKER_PASSWORD }}
+          registry: ghcr.io
+          username: ${{ github.repository_owner }}
+          password: ${{ secrets.GITHUB_TOKEN }}
       - name: Extract metadata (tags, labels) for Docker
         id: meta
         uses: docker/metadata-action@v5
         with:
           images: |
-            docker.io/${{ secrets.DOCKER_USERNAME }}/lagrange.onebot
+            ghcr.io/${{ github.repository_owner }}/lagrange.onebot
           tags: |
             type=edge
             type=sha,event=branch
@@ -45,5 +49,5 @@ jobs:
           push: true
           tags: ${{ steps.meta.outputs.tags }}
           labels: ${{ steps.meta.outputs.labels }}
-          platforms: linux/arm64/v8, linux/amd64
+          platforms: linux/arm64/v8, linux/amd64, linux/arm64
 

--- a/Docker.md
+++ b/Docker.md
@@ -1,0 +1,48 @@
+# Lagrange.Core
+
+[![Core](https://img.shields.io/badge/Lagrange-Core-blue)](#)
+[![OneBot](https://img.shields.io/badge/Lagrange-OneBot-blue)](#)
+[![C#](https://img.shields.io/badge/Core-%20.NET_6-blue)](#)
+[![C#](https://img.shields.io/badge/OneBot-%20.NET_7-blue)](#)
+
+[![License](https://img.shields.io/static/v1?label=LICENSE&message=GPL-3.0&color=lightrey)](#)
+[![Telegram](https://img.shields.io/endpoint?url=https%3A%2F%2Ftelegram-badge-4mbpu8e0fit4.runkit.sh%2F%3Furl%3Dhttps%3A%2F%2Ft.me%2F%2B6HNTeJO0JqtlNmRl)](https://t.me/+6HNTeJO0JqtlNmRl)
+
+An Implementation of NTQQ Protocol, with Pure C#, Derived from Konata.Core
+
+
+# Using with Docker
+
+```bash
+# 8081 port for ForwardWebSocket
+docker run -d -p 8081:8081 eric1008818/lagrange.onebot:edge
+```
+
+## Persistence Storage
+
+```bash
+docker volume create lagrange_data
+docker run -d -v lagrange_data:/app/data eric1008818/lagrange.onebot:edge
+```
+
+## Configure appsettings.json in Docker
+
+### Using Mount
+
+use bind mount to mount your `appsettings.json` to `/App/appsettings.json`		
+```bash
+docker run -d -v /etc/appsettings.json:/appsettings.json eric1008818/lagrange.onebot:edge
+```
+
+### Using Environment Variables
+
+use [Enviroment Variables](https://learn.microsoft.com/en-us/aspnet/core/fundamentals/configuration/?view=aspnetcore-7.0#naming-of-environment-variables) to set your appsettings.json
+```bash
+# disable reverse websocket
+docker run -d -e Implementations__1__Enable=false eric1008818/lagrange.onebot:edge
+```
+
+```bash
+# input username and password
+docker run -d -e Account__Uin=123456 -e Account__Password=1234 eric1008818/lagrange.onebot:edge
+```

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,16 @@
+FROM mcr.microsoft.com/dotnet/sdk:7.0-alpine3.18 AS build-env
+WORKDIR /App
+
+COPY . ./
+RUN dotnet publish Lagrange.OneBot/Lagrange.OneBot.csproj \
+        -c Release \
+        -o out \
+        --no-self-contained \
+        -p:PublishSingleFile=true \
+        -p:IncludeContentInSingleFile=true
+		
+FROM mcr.microsoft.com/dotnet/runtime:7.0-alpine3.18
+WORKDIR /app
+COPY --from=build-env /App/out .
+COPY appsettings.onebot.json ./appsettings.json
+ENTRYPOINT ["./Lagrange.OneBot"]

--- a/Lagrange.OneBot/Core/Network/LagrangeWebSvcCollection.cs
+++ b/Lagrange.OneBot/Core/Network/LagrangeWebSvcCollection.cs
@@ -36,6 +36,7 @@ public sealed partial class LagrangeWebSvcCollection(IServiceProvider services, 
         var operationSvc = services.GetRequiredService<OperationService>();
         foreach (var section in implsSection.GetChildren())
         {
+            if (section["Enable"] == "false") continue;
             var scope = services.CreateScope();
             var serviceProvider = scope.ServiceProvider;
             

--- a/Lagrange.OneBot/LagrangeAppBuilder.cs
+++ b/Lagrange.OneBot/LagrangeAppBuilder.cs
@@ -31,6 +31,7 @@ public sealed class LagrangeAppBuilder
     public LagrangeAppBuilder ConfigureConfiguration(string path, bool optional = false, bool reloadOnChange = false)
     {
         Configuration.AddJsonFile(path, optional, reloadOnChange);
+        Configuration.AddEnvironmentVariables(); // use this to configure appsettings.json with environment variables in docker container
         return this;
     }
 

--- a/appsettings.onebot.json
+++ b/appsettings.onebot.json
@@ -1,0 +1,40 @@
+{
+  "Logging": {
+    "LogLevel": {
+      "Default": "Information",
+      "Microsoft": "Warning",
+      "Microsoft.Hosting.Lifetime": "Information"
+    }
+  },
+  "ConfigPath": {
+    "Keystore": "./data/keystore.json",
+    "DeviceInfo": "./data/device.json",
+    "Database":  "./data/Lagrange.db"
+  },
+  "SignServerUrl": "",
+  "Account": {
+    "Uin": 0,
+    "Password": "",
+    "Protocol": "Linux",
+    "AutoReconnect": true,
+    "GetOptimumServer": true
+  },
+  "Implementations": [
+    {
+      "Type": "ForwardWebSocket",
+      "Host": "0.0.0.0",
+      "Port": 8081,
+      "HeartBeatInterval": 5000,
+      "AccessToken": ""
+    },
+    {
+      "Type": "ReverseWebSocket",
+      "Host": "127.0.0.1",
+      "Port": 8080,
+      "Suffix": "/onebot/v11/ws",
+      "ReconnectInterval": 5000,
+      "HeartBeatInterval": 5000,
+      "AccessToken": ""
+    }
+  ]
+}


### PR DESCRIPTION
此PR有幾點需要注意:
- ~~[Lagrange.OneBot-docker-push.yml](https://github.com/LagrangeDev/Lagrange.Core/compare/master...eric2788:Lagrange.Core:feature/docker?expand=1#diff-b2012289e932ce38f4b7bc9ecfc9a678b8dcb50162504f46b9255d7b8b967d89) 需要 `${{ secrets.DOCKER_USERNAME }}` 和 `${{ secrets.DOCKER_PASSWORD }}` 方可生效~~ 已轉用 github docker registry
- ~~目前的 Dockerfile 有 30% 概率會出現 `failed unexpectedly`, 再跑一次通常就能成功運行，目前原因未知~~ 應該修好了
- `appsettings.json` 采用 array 的原因是因爲容易讓 docker 透過 環境參數 進行操作
- `Lagrange.OneBot/Core/Network/LagrangeWebSvcCollection.cs` 新增 `section["Enable"]` 是爲了方便透過 docker 設置 環境參數 選擇使用哪個服務。注意：此改動是很久以前改的，新改動之後尚未知道有無兼容問題