### PR TITLE
Support CQ Code

### DIFF
--- a/Lagrange.OneBot/Core/Entity/Message/OneBotGroupMsg.cs
+++ b/Lagrange.OneBot/Core/Entity/Message/OneBotGroupMsg.cs
@@ -5,7 +5,7 @@ using Lagrange.OneBot.Core.Message;
 namespace Lagrange.OneBot.Core.Entity.Message;
 
 [Serializable]
-public class OneBotGroupMsg(uint selfId, uint groupUin, List<OneBotSegment> message, BotGroupMember member, uint messageId) : OneBotEntityBase(selfId, "message")
+public class OneBotGroupMsg(uint selfId, uint groupUin, List<OneBotSegment> message, string raw_message, BotGroupMember member, uint messageId) : OneBotEntityBase(selfId, "message")
 {
     [JsonPropertyName("message_type")] public string MessageType { get; set; } = "group";
 
@@ -21,7 +21,7 @@ public class OneBotGroupMsg(uint selfId, uint groupUin, List<OneBotSegment> mess
 
     [JsonPropertyName("message")] public List<OneBotSegment> Message { get; set; } = message;
 
-    [JsonPropertyName("raw_message")] public string RawMessage { get; set; } = string.Empty;
+    [JsonPropertyName("raw_message")] public string RawMessage { get; set; } = raw_message;
 
     [JsonPropertyName("font")] public int Font { get; set; } = 0;
 

--- a/Lagrange.OneBot/Core/Operation/Message/MessageCommon.cs
+++ b/Lagrange.OneBot/Core/Operation/Message/MessageCommon.cs
@@ -1,5 +1,6 @@
 using System.Reflection;
 using System.Text.Json;
+using System.Text.RegularExpressions;
 using Lagrange.Core.Message;
 using Lagrange.Core.Utility.Extension;
 using Lagrange.OneBot.Core.Entity.Action;
@@ -8,21 +9,21 @@ using Lagrange.OneBot.Core.Message;
 
 namespace Lagrange.OneBot.Core.Operation.Message;
 
-public static class MessageCommon
+public static partial class MessageCommon
 {
     private static readonly Dictionary<string, ISegment> TypeToSegment;
-    
+
     static MessageCommon()
     {
         TypeToSegment = new Dictionary<string, ISegment>();
-        
+
         foreach (var type in Assembly.GetExecutingAssembly().GetTypes())
         {
             var attribute = type.GetCustomAttribute<SegmentSubscriberAttribute>();
             if (attribute != null) TypeToSegment[attribute.SendType] = (ISegment)type.CreateInstance(false);
         }
     }
-    
+
     public static MessageBuilder ParseChain(OneBotMessage message)
     {
         var builder = message.MessageType == "private"
@@ -32,7 +33,7 @@ public static class MessageCommon
 
         return builder;
     }
-    
+
     public static MessageBuilder ParseChain(OneBotMessageSimple message)
     {
         var builder = message.MessageType == "private"
@@ -42,7 +43,7 @@ public static class MessageCommon
 
         return builder;
     }
-    
+
     public static MessageBuilder ParseChain(OneBotMessageText message)
     {
         var builder = message.MessageType == "private"
@@ -52,7 +53,7 @@ public static class MessageCommon
 
         return builder;
     }
-    
+
     public static MessageBuilder ParseChain(OneBotPrivateMessage message)
     {
         var builder = MessageBuilder.Friend(message.UserId);
@@ -60,7 +61,7 @@ public static class MessageCommon
 
         return builder;
     }
-    
+
     public static MessageBuilder ParseChain(OneBotPrivateMessageSimple message)
     {
         var builder = MessageBuilder.Friend(message.UserId);
@@ -68,16 +69,22 @@ public static class MessageCommon
 
         return builder;
     }
-    
+
     public static MessageBuilder ParseChain(OneBotPrivateMessageText message)
     {
-        var builder = MessageBuilder.Group(message.UserId);
-        builder.Text(message.Messages);
-
+        var builder = MessageBuilder.Friend(message.UserId);
+        if (message.AutoEscape == true)
+        {
+            builder.Text(message.Messages);
+        }
+        else
+        {
+            BuildMessages(builder, message.Messages);
+        }
         return builder;
     }
 
-    
+
     public static MessageBuilder ParseChain(OneBotGroupMessage message)
     {
         var builder = MessageBuilder.Group(message.GroupId);
@@ -85,7 +92,7 @@ public static class MessageCommon
 
         return builder;
     }
-    
+
     public static MessageBuilder ParseChain(OneBotGroupMessageSimple message)
     {
         var builder = MessageBuilder.Group(message.GroupId);
@@ -93,13 +100,63 @@ public static class MessageCommon
 
         return builder;
     }
-    
+
     public static MessageBuilder ParseChain(OneBotGroupMessageText message)
     {
         var builder = MessageBuilder.Group(message.GroupId);
-        builder.Text(message.Messages);
-
+        if (message.AutoEscape == true)
+        {
+            builder.Text(message.Messages);
+        }
+        else
+        {
+            BuildMessages(builder, message.Messages);
+        }
         return builder;
+    }
+
+    [GeneratedRegex(@"\[CQ:([^,\]]+)(?:,([^,\]]+))*\]")]
+    private static partial Regex CQCodeRegex();
+
+    private static string UnescapeCQ(string str)
+    {
+        return str.Replace("&#91;", "[")
+                  .Replace("&#93;", "]")
+                  .Replace("&#44;", ",")
+                  .Replace("&amp;", "&");
+    }
+
+    private static string UnescapeText(string str)
+    {
+        return str.Replace("&#91;", "[")
+                  .Replace("&#93;", "]")
+                  .Replace("&amp;", "&");
+    }
+
+    private static void BuildMessages(MessageBuilder builder, string message)
+    {
+        var matches = CQCodeRegex().Matches(message);
+        int textStart = 0;
+        foreach (var match in matches.Cast<Match>())
+        {
+            if (match.Index > textStart) builder.Text(UnescapeText(message[textStart..match.Index]));
+            textStart = match.Index + match.Length;
+
+            string type = match.Groups[1].Value;
+            if (TypeToSegment.TryGetValue(type, out var instance))
+            {
+                var data = new Dictionary<string, string>();
+                foreach (var capture in match.Groups[2].Captures.Cast<Capture>())
+                {
+                    var pair = capture.Value.Split('=', 2);
+                    if (pair.Length == 2) data[pair[0]] = UnescapeCQ(pair[1]);
+                }
+                var cast = (ISegment)JsonSerializer.SerializeToElement(data).Deserialize(instance.GetType())!;
+                instance.Build(builder, cast);
+            }
+        }
+
+        if (textStart < message.Length) builder.Text(UnescapeText(message[textStart..]));
     }
 
     private static void BuildMessages(MessageBuilder builder, List<OneBotSegment> segments)
@@ -113,13 +170,13 @@ public static class MessageCommon
             }
         }
     }
-    
+
     private static void BuildMessages(MessageBuilder builder, OneBotSegment segment)
     {
-            if (TypeToSegment.TryGetValue(segment.Type, out var instance))
-            {
-                var cast = (ISegment)((JsonElement)segment.Data).Deserialize(instance.GetType())!;
-                instance.Build(builder, cast);
-            }
+        if (TypeToSegment.TryGetValue(segment.Type, out var instance))
+        {
+            var cast = (ISegment)((JsonElement)segment.Data).Deserialize(instance.GetType())!;
+            instance.Build(builder, cast);
+        }
     }
 }


### PR DESCRIPTION
1. CQ Code parse is implemented using regex
2. only `OneBotGroupMessageText` with `AutoEscape == true` will send raw message now
https://github.com/LagrangeDev/Lagrange.Core/blob/36144c8110acd1b9ed57ad4e449adaf0e8d431e4/Lagrange.OneBot/Core/Operation/Message/MessageCommon.cs#L73-L79
3. `raw_message` is provided, fixes #72 