### PR TITLE
fix can't-execute-Lagrange.Core-nuget-push.yml-when-push

### DIFF
--- a/.github/workflows/Lagrange.Core-nuget-push.yml
+++ b/.github/workflows/Lagrange.Core-nuget-push.yml
@@ -10,7 +10,7 @@ on:
 
 jobs:
   build:
-    if: github.event.pull_request.merged == true
+    if: github.event_name == 'push' || github.event.pull_request.merged == true
     
     runs-on: windows-latest
 


### PR DESCRIPTION
fix can't execute Lagrange.Core-nuget-push.yml when push