### PR TITLE
Fix README navigator

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,12 +1,19 @@
 <div align="center">
 
-
-<span></span>|<span></span>
--|-
-[Lagrange.Core](https://github.com/LagrangeDev/Lagrange.Core)|NTQQ Protocol Implementation（👈Here
-[OpenShamrock](https://github.com/whitechi73/OpenShamrock)|Based on Xposed, OneBot Bot Framework
-[Chronocat](https://github.com/chrononeko/chronocat)|Based on Electron, modular Satori Bot Framework
-
+<table>
+<tr>
+  <td><a href="https://github.com/LagrangeDev/Lagrange.Core">Lagrange.Core</a></td>
+  <td>NTQQ Protocol Implementation（👈Here</td>
+</tr>
+<tr>
+  <td><a href="https://github.com/whitechi73/OpenShamrock">OpenShamrock</a></td>
+  <td>Based on Xposed, OneBot Bot Framework</td>
+</tr>
+<tr>
+  <td><a href="https://github.com/chrononeko/chronocat">Chronocat</a></td>
+  <td>Based on Electron, modular Satori Bot Framework</td>
+</tr>
+</table>
 
 
 # Lagrange.Core

--- a/README_zh.md
+++ b/README_zh.md
@@ -1,10 +1,19 @@
 <div align="center">
 
-<span></span>|<span></span>
--|-
-[Lagrange.Core](https://github.com/LagrangeDev/Lagrange.Core)|NTQQ 的协议实现（👈你在这里
-[OpenShamrock](https://github.com/whitechi73/OpenShamrock)|基于 Xposed 实现 OneBot 标准的机器人框架
-[Chronocat](https://github.com/chrononeko/chronocat)|基于 Electron 的、模块化的 Satori 框架
+<table>
+<tr>
+  <td><a href="https://github.com/LagrangeDev/Lagrange.Core">Lagrange.Core</a></td>
+  <td>NTQQ 的协议实现（👈你在这里</td>
+</tr>
+<tr>
+  <td><a href="https://github.com/whitechi73/OpenShamrock">OpenShamrock</a></td>
+  <td>基于 Lsposed 实现 OneBot 标准的机器人框架</td>
+</tr>
+<tr>
+  <td><a href="https://github.com/chrononeko/chronocat">Chronocat</a></td>
+  <td>基于 Electron 的、模块化的 Satori 框架</td>
+</tr>
+</table>
 
 # Lagrange.Core
 


### PR DESCRIPTION
### Description
Cannot stand that rendering of markdown table with empty header, use raw HTML table instead.

### Validation Cases
  - [x] Manual check rendering on Github after converted to raw HTML.
    ![image](https://github.com/LagrangeDev/Lagrange.Core/assets/41534161/39341a5b-516a-421a-8af0-6bd418dde1d0)
    
