### PR TITLE
[OneBot] HttpService: remove port detection related code

### DIFF
--- a/Lagrange.OneBot/Core/Network/Service/HttpService.cs
+++ b/Lagrange.OneBot/Core/Network/Service/HttpService.cs
@@ -26,13 +26,6 @@ public sealed partial class HttpService(
 
     protected override async Task ExecuteAsync(CancellationToken token)
     {
-        uint port = _options.Port;
-        if (IsPortInUse(port))
-        {
-            Log.LogPortInUse(_logger, port);
-            return;
-        }
-
         string prefix = $"http://{_options.Host}:{_options.Port}/";
 
         try
@@ -193,9 +186,6 @@ public sealed partial class HttpService(
         }
     }
 
-    private static bool IsPortInUse(uint port) =>
-        IPGlobalProperties.GetIPGlobalProperties().GetActiveTcpListeners().Any(endpoint => endpoint.Port == port);
-
     private static partial class Log
     {
         [LoggerMessage(EventId = 0, Level = LogLevel.Information, Message = "HttpService started at {prefix}")]
@@ -208,32 +198,28 @@ public sealed partial class HttpService(
         public static partial void LogSend(ILogger logger, string identifier, string s);
 
 
-        [LoggerMessage(EventId = 992, Level = LogLevel.Warning, Message = "Conn: {identifier} auth failed")]
+        [LoggerMessage(EventId = 993, Level = LogLevel.Warning, Message = "Conn: {identifier} auth failed")]
         public static partial void LogAuthFailed(ILogger logger, string identifier);
 
-        [LoggerMessage(EventId = 993, Level = LogLevel.Warning, Message = "Unsupported content type: {contentType}")]
+        [LoggerMessage(EventId = 994, Level = LogLevel.Warning, Message = "Unsupported content type: {contentType}")]
         public static partial void LogUnsupportedContentType(ILogger logger, string contentType);
 
-        [LoggerMessage(EventId = 994, Level = LogLevel.Warning, Message = "Unsupported method: {method}")]
+        [LoggerMessage(EventId = 995, Level = LogLevel.Warning, Message = "Unsupported method: {method}")]
         public static partial void LogUnsupportedMethod(ILogger logger, string method);
 
-        [LoggerMessage(EventId = 995, Level = LogLevel.Warning,
+        [LoggerMessage(EventId = 996, Level = LogLevel.Warning,
             Message = "An error occurred while handling the request")]
         public static partial void LogHandleError(ILogger logger, Exception e);
 
-        [LoggerMessage(EventId = 996, Level = LogLevel.Warning,
+        [LoggerMessage(EventId = 997, Level = LogLevel.Warning,
             Message = "An error occurred while getting the context")]
         public static partial void LogGetContextError(ILogger logger, Exception e);
 
-        [LoggerMessage(EventId = 997, Level = LogLevel.Warning, Message = "Failed to gracefully close the listener")]
+        [LoggerMessage(EventId = 998, Level = LogLevel.Warning, Message = "Failed to gracefully close the listener")]
         public static partial void LogCloseFailed(ILogger logger, Exception e);
 
-        [LoggerMessage(EventId = 998, Level = LogLevel.Error,
+        [LoggerMessage(EventId = 999, Level = LogLevel.Error,
             Message = "An error occurred while starting the listener")]
         public static partial void LogStartFailed(ILogger logger, Exception e);
-
-        [LoggerMessage(EventId = 999, Level = LogLevel.Error,
-            Message = "The port {port} is in use, service failed to start")]
-        public static partial void LogPortInUse(ILogger logger, uint port);
     }
 }


### PR DESCRIPTION
remove `IsPortInUse`, leave the port duplication problem for user to care of.

fixes #358 