### PR TITLE
[Core]Change the access level of MultiMsgEntity's constructor to public

### DIFF
--- a/Lagrange.Core/Message/Entity/MultiMsgEntity.cs
+++ b/Lagrange.Core/Message/Entity/MultiMsgEntity.cs
@@ -22,13 +22,13 @@ public class MultiMsgEntity : IMessageEntity
 
     internal MultiMsgEntity() => Chains = new List<MessageChain>();
 
-    internal MultiMsgEntity(string resId)
+    public MultiMsgEntity(string resId)
     {
         ResId = resId;
         Chains = new List<MessageChain>();
     }
 
-    internal MultiMsgEntity(uint? groupUin, List<MessageChain> chains)
+    public MultiMsgEntity(uint? groupUin, List<MessageChain> chains)
     {
         GroupUin = groupUin;
         Chains = chains;


### PR DESCRIPTION
To ensure consistency with other IMessageEntity classes, programs developed with Core can directly use the constructor to initialize MultiMsgEntity objects.