### PR TITLE
[OneBot] Support Sign Http Proxy And Exposing Builder Ctor

### DIFF
--- a/Lagrange.OneBot/LagrangeAppBuilder.cs
+++ b/Lagrange.OneBot/LagrangeAppBuilder.cs
@@ -23,7 +23,7 @@ public sealed class LagrangeAppBuilder
     
     private readonly HostApplicationBuilder _hostAppBuilder;
 
-    internal LagrangeAppBuilder(string[] args)
+    public LagrangeAppBuilder(string[] args)
     {
         _hostAppBuilder = new HostApplicationBuilder(args);
     }

--- a/Lagrange.OneBot/Resources/appsettings.json
+++ b/Lagrange.OneBot/Resources/appsettings.json
@@ -7,6 +7,7 @@
         }
     },
     "SignServerUrl": "https://sign.lagrangecore.org/api/sign/25765",
+    "SignProxyUrl": "",
     "MusicSignServerUrl": "",
     "Account": {
         "Uin": 0,

--- a/Lagrange.OneBot/Utility/OneBotSigner.cs
+++ b/Lagrange.OneBot/Utility/OneBotSigner.cs
@@ -1,4 +1,5 @@
 using System.Diagnostics.CodeAnalysis;
+using System.Net;
 using System.Net.Http.Json;
 using System.Text;
 using System.Text.Json;
@@ -23,7 +24,20 @@ public class OneBotSigner : SignProvider
     {
         _signServer = config["SignServerUrl"] ?? "";
         _logger = logger;
-        _client = new HttpClient();
+        var signProxyUrl = config["SignProxyUrl"];
+        //Only support HTTP proxy
+
+        _client = new HttpClient(handler: new HttpClientHandler
+        {
+            Proxy = string.IsNullOrEmpty(signProxyUrl) ? null : new WebProxy()
+            {
+                Address = new Uri(signProxyUrl),
+                BypassProxyOnLocal = false,
+                UseDefaultCredentials = false,
+            },
+            UseProxy = !string.IsNullOrEmpty(signProxyUrl),
+        },
+        disposeHandler: true);
         
         if (string.IsNullOrEmpty(_signServer))
         {


### PR DESCRIPTION
Only Http, Not support https and socks5 (so f**king ms)