### PR TITLE
[Core] public file id

### DIFF
--- a/Lagrange.Core/Common/Entity/BotFileEntry.cs
+++ b/Lagrange.Core/Common/Entity/BotFileEntry.cs
@@ -3,7 +3,7 @@ namespace Lagrange.Core.Common.Entity;
 [Serializable]
 public class BotFileEntry : IBotFSEntry
 {
-    internal string FileId { get; }
+    public string FileId { get; }
     
     public string FileName { get; }
     


### PR DESCRIPTION
Now all operations on group files use FileId

Setting the field permission to internal is unreasonable