### PR TITLE
[All] new api - GetC2CMessage; fix multiple errors

### DIFF
--- a/Lagrange.Core/Common/Interface/Api/OperationExt.cs
+++ b/Lagrange.Core/Common/Interface/Api/OperationExt.cs
@@ -148,8 +148,13 @@ public static class OperationExt
     /// <param name="count">number of message to be fetched before timestamp</param>
     public static Task<List<MessageChain>?> GetRoamMessage(this BotContext bot, MessageChain targetChain, uint count)
     {
-        uint timestamp = (uint)(targetChain.Time - new DateTime(1970, 1, 1, 0, 0, 0, 0, DateTimeKind.Utc)).TotalSeconds;
+        uint timestamp = (uint)new DateTimeOffset(targetChain.Time).ToUnixTimeSeconds();
         return bot.ContextCollection.Business.OperationLogic.GetRoamMessage(targetChain.FriendUin, timestamp, count);
+    }
+
+    public static Task<List<MessageChain>?> GetC2cMessage(this BotContext bot, uint friendUin, uint startSequence, uint endSequence)
+    {
+        return bot.ContextCollection.Business.OperationLogic.GetC2cMessage(friendUin, startSequence, endSequence);
     }
 
     /// <summary>

--- a/Lagrange.Core/Internal/Context/Logic/Implementation/OperationLogic.cs
+++ b/Lagrange.Core/Internal/Context/Logic/Implementation/OperationLogic.cs
@@ -172,7 +172,7 @@ internal class OperationLogic : LogicBase
         var retMsg = events.Count > 0 ? ((GroupFSCreateFolderEvent)events[0]).RetMsg : "";
         return new(retCode, retMsg);
     }
-    
+
     public async Task<(int, string)> GroupFSDeleteFolder(uint groupUin, string folderId)
     {
         var groupFSDeleteFolderEvent = GroupFSDeleteFolderEvent.Create(groupUin, folderId);
@@ -378,6 +378,15 @@ internal class OperationLogic : LogicBase
         var roamEvent = GetRoamMessageEvent.Create(uid, time, count);
         var results = await Collection.Business.SendEvent(roamEvent);
         return results.Count != 0 ? ((GetRoamMessageEvent)results[0]).Chains : null;
+    }
+
+    public async Task<List<MessageChain>?> GetC2cMessage(uint friendUin, uint startSequence, uint endSequence)
+    {
+        if (await Collection.Business.CachingLogic.ResolveUid(null, friendUin) is not { } uid) return null;
+
+        var c2cEvent = GetC2cMessageEvent.Create(uid, startSequence, endSequence);
+        var results = await Collection.Business.SendEvent(c2cEvent);
+        return results.Count != 0 ? ((GetC2cMessageEvent)results[0]).Chains : null;
     }
 
     public async Task<List<string>?> FetchCustomFace()

--- a/Lagrange.Core/Internal/Event/Message/GetC2cMessageEvent.cs
+++ b/Lagrange.Core/Internal/Event/Message/GetC2cMessageEvent.cs
@@ -1,0 +1,32 @@
+using Lagrange.Core.Message;
+
+namespace Lagrange.Core.Internal.Event.Message;
+
+internal class GetC2cMessageEvent : ProtocolEvent
+{
+    public string FriendUid { get; } = string.Empty;
+
+    public uint StartSequence { get; }
+
+    public uint EndSequence { get; }
+
+    public List<MessageChain> Chains { get; } = new();
+
+    private GetC2cMessageEvent(string friendUid, uint startSequence, uint endSequence) : base(true)
+    {
+        FriendUid = friendUid;
+        StartSequence = startSequence;
+        EndSequence = endSequence;
+    }
+
+    private GetC2cMessageEvent(List<MessageChain> chains) : base(0)
+    {
+        Chains = chains;
+    }
+
+    public static GetC2cMessageEvent Create(string friendUid, uint startSequence, uint endSequence)
+        => new(friendUid, startSequence, endSequence);
+
+    public static GetC2cMessageEvent Result(List<MessageChain> chains)
+        => new(chains);
+}

--- a/Lagrange.Core/Internal/Packets/Message/Action/SsoGetC2cMsg.cs
+++ b/Lagrange.Core/Internal/Packets/Message/Action/SsoGetC2cMsg.cs
@@ -1,0 +1,16 @@
+using ProtoBuf;
+
+namespace Lagrange.Core.Internal.Packets.Message.Action;
+
+/// <summary>
+/// trpc.msg.register_proxy.RegisterProxy.SsoGetC2cMsg
+/// </summary>
+[ProtoContract]
+internal class SsoGetC2cMsg
+{
+    [ProtoMember(2)] public string? FriendUid { get; set; }
+
+    [ProtoMember(3)] public uint StartSequence { get; set; }
+
+    [ProtoMember(4)] public uint EndSequence { get; set; }
+}

--- a/Lagrange.Core/Internal/Packets/Message/Action/SsoGetC2cMsgResponse.cs
+++ b/Lagrange.Core/Internal/Packets/Message/Action/SsoGetC2cMsgResponse.cs
@@ -1,0 +1,13 @@
+using ProtoBuf;
+
+namespace Lagrange.Core.Internal.Packets.Message.Action;
+
+#pragma warning disable CS8618
+
+[ProtoContract]
+internal class SsoGetC2cMsgResponse
+{
+    [ProtoMember(4)] public string FriendUid { get; set; }
+
+    [ProtoMember(7)] public List<PushMsgBody>? Messages { get; set; }
+}

--- a/Lagrange.Core/Internal/Packets/Message/ContentHead.cs
+++ b/Lagrange.Core/Internal/Packets/Message/ContentHead.cs
@@ -8,24 +8,26 @@ namespace Lagrange.Core.Internal.Packets.Message;
 internal class ContentHead
 {
     [ProtoMember(1)] public uint Type { get; set; }
-    
+
     [ProtoMember(2)] public uint? SubType { get; set; }
-    
+
     [ProtoMember(3)] public uint? DivSeq { get; set; }
-    
+
     [ProtoMember(4)] public long? MsgId { get; set; }
-    
+
     [ProtoMember(5)] public uint? Sequence { get; set; }
-    
+
     [ProtoMember(6)] public long? Timestamp { get; set; }
-    
+
     [ProtoMember(7)] public long? Field7 { get; set; }
-    
+
     [ProtoMember(8)] public uint? Field8 { get; set; }
 
     [ProtoMember(9)] public uint? Field9 { get; set; }
-    
+
+    [ProtoMember(11)] public uint? FriendSequence { get; set; }
+
     [ProtoMember(12)] public ulong? NewId { get; set; }
-    
+
     [ProtoMember(15)] public ForwardHead? Forward { get; set; }
 }

--- a/Lagrange.Core/Internal/Packets/Message/Element/Implementation/SourceMsg.PbPreserve.cs
+++ b/Lagrange.Core/Internal/Packets/Message/Element/Implementation/SourceMsg.PbPreserve.cs
@@ -8,11 +8,11 @@ internal partial class SrcMsg
     internal class Preserve
     {
         [ProtoMember(3)] public ulong MessageId { get; set; }
-        
+
         [ProtoMember(6)] public string? SenderUid { get; set; }
-        
+
         [ProtoMember(7)] public string? ReceiverUid { get; set; }
-        
-        [ProtoMember(8)] public uint? ClientSequence { get; set; }
+
+        [ProtoMember(8)] public uint? FriendSequence { get; set; }
     }
 }

--- a/Lagrange.Core/Internal/Service/Message/GetC2cMessageService.cs
+++ b/Lagrange.Core/Internal/Service/Message/GetC2cMessageService.cs
@@ -1,0 +1,40 @@
+using Lagrange.Core.Common;
+using Lagrange.Core.Internal.Event;
+using Lagrange.Core.Internal.Event.Message;
+using Lagrange.Core.Internal.Packets.Message.Action;
+using Lagrange.Core.Message;
+using Lagrange.Core.Utility.Extension;
+using ProtoBuf;
+
+namespace Lagrange.Core.Internal.Service.Message;
+
+[EventSubscribe(typeof(GetC2cMessageEvent))]
+[Service("trpc.msg.register_proxy.RegisterProxy.SsoGetC2cMsg")]
+internal class GetC2cMessageService : BaseService<GetC2cMessageEvent>
+{
+    protected override bool Build(GetC2cMessageEvent input, BotKeystore keystore, BotAppInfo appInfo,
+        BotDeviceInfo device, out Span<byte> output, out List<Memory<byte>>? extraPackets)
+    {
+        var packet = new SsoGetC2cMsg
+        {
+            FriendUid = input.FriendUid,
+            StartSequence = input.StartSequence,
+            EndSequence = input.EndSequence
+        };
+
+        output = packet.Serialize();
+        extraPackets = null;
+        return true;
+    }
+
+    protected override bool Parse(Span<byte> input, BotKeystore keystore, BotAppInfo appInfo, BotDeviceInfo device,
+        out GetC2cMessageEvent output, out List<ProtocolEvent>? extraEvents)
+    {
+        var payload = Serializer.Deserialize<SsoGetC2cMsgResponse>(input);
+        var chains = payload.Messages?.Select(x => MessagePacker.Parse(x)).ToList() ?? new();
+
+        output = GetC2cMessageEvent.Result(chains);
+        extraEvents = null;
+        return true;
+    }
+}

--- a/Lagrange.Core/Message/MessageChain.cs
+++ b/Lagrange.Core/Message/MessageChain.cs
@@ -24,6 +24,8 @@ public sealed class MessageChain : List<IMessageEntity>
 
     public uint Sequence { get; internal set; }
 
+    public uint ClientSequence { get; internal set; }
+
     #region Internal Properties
 
     internal string? SelfUid { get; set; }
@@ -36,13 +38,14 @@ public sealed class MessageChain : List<IMessageEntity>
 
     #endregion
 
-    internal MessageChain(uint friendUin, string selfUid, string friendUid, uint targetUin = 0, uint sequence = 0, ulong? messageId = null,
+    internal MessageChain(uint friendUin, string selfUid, string friendUid, uint targetUin = 0, uint sequence = 0, uint clientSequence = 0, ulong? messageId = null,
         MessageType type = MessageType.Friend)
     {
         GroupUin = null;
         FriendUin = friendUin;
         TargetUin = targetUin;
         Sequence = sequence; // unuseful at there
+        ClientSequence = clientSequence;
         SelfUid = selfUid;
         Uid = friendUid;
         MessageId = messageId ?? (0x10000000ul << 32) | (uint)Random.Shared.Next(100000000, int.MaxValue);

--- a/Lagrange.Core/Message/MessagePacker.cs
+++ b/Lagrange.Core/Message/MessagePacker.cs
@@ -25,7 +25,7 @@ internal static class MessagePacker
 {
     private static readonly Dictionary<Type, List<PropertyInfo>> EntityToElem;
     private static readonly Dictionary<Type, IMessageEntity> Factory;
-    
+
     static MessagePacker()
     {
         EntityToElem = new Dictionary<Type, List<PropertyInfo>>();
@@ -34,7 +34,7 @@ internal static class MessagePacker
         var assembly = Assembly.GetExecutingAssembly();
         var types = assembly.GetTypeWithMultipleAttributes<MessageElementAttribute>(out var attributeArrays);
         var elemType = typeof(Elem);
-        
+
         for (int i = 0; i < types.Count; i++)
         {
             var type = types[i];
@@ -73,12 +73,12 @@ internal static class MessagePacker
                 message.Body.MsgContent = stream.ToArray();
             }
         }
-        
+
         BuildAdditional(chain, message);
 
         return message;
     }
-    
+
     public static PushMsgBody BuildFake(MessageChain chain, string selfUid)
     {
         var message = BuildFakePacketBase(chain, selfUid);
@@ -87,7 +87,7 @@ internal static class MessagePacker
         {
             entity.SetSelfUid(selfUid);
             message.Body?.RichText?.Elems.AddRange(entity.PackElement());
-            
+
             if (message.Body != null)
             {
                 if (entity.PackMessageContent() is not { } content) continue;
@@ -104,7 +104,7 @@ internal static class MessagePacker
     private static void BuildAdditional(MessageChain chain, Internal.Packets.Message.Message message)
     {
         if (message.Body?.RichText == null) return;
-        
+
         foreach (var entity in chain)
         {
             switch (entity)
@@ -118,12 +118,12 @@ internal static class MessagePacker
             }
         }
     }
-    
+
     public static MessageChain Parse(PushMsgBody message, bool isFake = false)
     {
         var chain = isFake ? ParseFakeChain(message) : ParseChain(message);
 
-        if (message.Body?.RichText is { Elems: { } elements}) // 怎么Body还能是null的
+        if (message.Body?.RichText is { Elems: { } elements }) // 怎么Body还能是null的
         {
             foreach (var element in elements)
             {
@@ -131,7 +131,7 @@ internal static class MessagePacker
                 {
                     foreach (var expectElem in expectElems)
                     {
-                        if (expectElem.GetValueByExpr(element) is not null && 
+                        if (expectElem.GetValueByExpr(element) is not null &&
                             Factory[entityType].UnpackElement(element) is { } entity)
                         {
                             chain.Add(entity);
@@ -147,8 +147,8 @@ internal static class MessagePacker
             case { } groupPtt when chain.IsGroup && groupPtt.FileId != 0:  //  for legacy ptt
                 chain.Add(new RecordEntity(groupPtt.GroupFileKey, groupPtt.FileName));
                 break;
-            case { } privatePtt when !chain.IsGroup: 
-                if (chain.OfType<RecordEntity>().FirstOrDefault(x => x.AudioName == privatePtt.FileName) == null) 
+            case { } privatePtt when !chain.IsGroup:
+                if (chain.OfType<RecordEntity>().FirstOrDefault(x => x.AudioName == privatePtt.FileName) == null)
                     chain.Add(new RecordEntity(privatePtt.FileUuid, privatePtt.FileName));
                 break;
         }
@@ -159,13 +159,13 @@ internal static class MessagePacker
     public static MessageChain ParsePrivateFile(PushMsgBody message)
     {
         if (message.Body?.MsgContent == null) throw new Exception();
-        
+
         var chain = ParseChain(message);
 
         var extra = Serializer.Deserialize<FileExtra>(message.Body.MsgContent.AsSpan());
         var file = extra.File;
 
-        if ( file is { FileSize: not null, FileName: not null, FileMd5: not null, FileUuid: not null, FileHash: not null })
+        if (file is { FileSize: not null, FileName: not null, FileMd5: not null, FileUuid: not null, FileHash: not null })
         {
             chain.Add(new FileEntity((long)file.FileSize, file.FileName, file.FileMd5, file.FileUuid, file.FileHash));
             return chain;
@@ -243,29 +243,30 @@ internal static class MessagePacker
         },
         Body = new MessageBody { RichText = new RichText { Elems = new List<Elem>() } }
     };
-    
+
     private static MessageChain ParseChain(PushMsgBody message)
     {
         var chain = message.ResponseHead.Grp == null
             ? new MessageChain(
                 message.ResponseHead.FromUin,
-                message.ResponseHead.ToUid ?? string.Empty , 
-                message.ResponseHead.FromUid ?? string.Empty, 
+                message.ResponseHead.ToUid ?? string.Empty,
+                message.ResponseHead.FromUid ?? string.Empty,
                 message.ResponseHead.ToUin,
+                message.ContentHead.FriendSequence ?? 0,
                 message.ContentHead.Sequence ?? 0,
                 message.ContentHead.NewId ?? 0,
                 message.ContentHead.Type == 141 ? MessageChain.MessageType.Temp : MessageChain.MessageType.Friend)
-            
+
             : new MessageChain(
-                message.ResponseHead.Grp.GroupUin, 
-                message.ResponseHead.FromUin, 
+                message.ResponseHead.Grp.GroupUin,
+                message.ResponseHead.FromUin,
                 message.ContentHead.Sequence ?? 0,
                 message.ContentHead.NewId ?? 0);
 
         if (message.Body?.RichText?.Elems is { } elems) chain.Elements.AddRange(elems);
 
         chain.Time = DateTimeOffset.FromUnixTimeSeconds(message.ContentHead.Timestamp ?? 0).LocalDateTime;
-        
+
         return chain;
     }
 
@@ -286,7 +287,7 @@ internal static class MessagePacker
         {
             @base.FriendInfo = new BotFriend(0, message.ResponseHead.FromUid ?? string.Empty, message.ResponseHead.Forward?.FriendName ?? string.Empty, string.Empty, string.Empty, string.Empty);
         }
-        
+
         return @base;
     }
 

--- a/Lagrange.OneBot/Database/MessageRecord.cs
+++ b/Lagrange.OneBot/Database/MessageRecord.cs
@@ -8,21 +8,23 @@ namespace Lagrange.OneBot.Database;
 public class MessageRecord
 {
     public uint FriendUin { get; set; }
-    
+
     public uint GroupUin { get; set; }
 
     public uint Sequence { get; set; }
-    
+
+    public uint ClientSequence { get; set; }
+
     public DateTime Time { get; set; }
-    
+
     public ulong MessageId { get; set; }
-    
+
     public BotFriend? FriendInfo { get; set; }
-    
+
     public BotGroupMember? GroupMemberInfo { get; set; }
 
     public List<IMessageEntity> Entities { get; set; } = [];
-    
+
     public int MessageHash { get; set; }
 
     static MessageRecord()
@@ -32,23 +34,24 @@ public class MessageRecord
 
     public static explicit operator MessageChain(MessageRecord record)
     {
-        var chain = record.GroupUin != 0 
-            ? new MessageChain(record.GroupUin, record.FriendUin, record.Sequence, record.MessageId) 
-            : new MessageChain(record.FriendUin, string.Empty, string.Empty, 0, record.Sequence, record.MessageId);
+        var chain = record.GroupUin != 0
+            ? new MessageChain(record.GroupUin, record.FriendUin, record.Sequence, record.MessageId)
+            : new MessageChain(record.FriendUin, string.Empty, string.Empty, 0, record.Sequence, record.ClientSequence, record.MessageId);
 
         chain.Time = record.Time;
         chain.FriendInfo = record.FriendInfo;
         chain.GroupMemberInfo = record.GroupMemberInfo;
-        
+
         chain.AddRange(record.Entities);
         return chain;
     }
-    
+
     public static explicit operator MessageRecord(MessageChain chain) => new()
     {
         FriendUin = chain.FriendUin,
         GroupUin = chain.GroupUin ?? 0,
         Sequence = chain.Sequence,
+        ClientSequence = chain.ClientSequence,
         Time = chain.Time,
         MessageId = chain.MessageId,
         FriendInfo = chain.FriendInfo,
@@ -65,7 +68,7 @@ public class MessageRecord
         byte[] id = [messageId[0], messageId[1], sequence[0], sequence[1]];
         return BitConverter.ToInt32(id.AsSpan());
     }
-    
+
     public static int CalcMessageHash(uint random, uint seq)
     {
         var messageId = BitConverter.GetBytes(random);

--- a/Lagrange.OneBot/Message/Entity/ReplySegment.cs
+++ b/Lagrange.OneBot/Message/Entity/ReplySegment.cs
@@ -10,26 +10,27 @@ public partial class ReplySegment(uint messageId)
 {
     public ReplySegment() : this(0) { }
 
-    [JsonPropertyName("id")] [CQProperty] public string MessageId { get; set; } = messageId.ToString();
+    [JsonPropertyName("id")][CQProperty] public string MessageId { get; set; } = messageId.ToString();
 }
 
 [SegmentSubscriber(typeof(ForwardEntity), "reply")]
 public partial class ReplySegment : SegmentBase
 {
     internal MessageChain? TargetChain { get; set; }
-    
+
     internal uint Sequence { get; private set; }
-    
+
     public override void Build(MessageBuilder builder, SegmentBase segment)
     {
         if (segment is ReplySegment reply && Database is not null)
         {
-            reply.TargetChain ??= (MessageChain)Database.GetCollection<MessageRecord>().FindById(int.Parse(reply.MessageId));
+            var messageRecord = Database.GetCollection<MessageRecord>().FindById(int.Parse(reply.MessageId));
+            reply.TargetChain ??= (MessageChain)messageRecord;
 
             var build = MessagePacker.Build(reply.TargetChain, "");
             var virtualElem = build.Body?.RichText?.Elems;
             if (virtualElem != null) reply.TargetChain.Elements.AddRange(virtualElem);
-            
+
             builder.Forward(reply.TargetChain);
         }
     }
@@ -37,9 +38,9 @@ public partial class ReplySegment : SegmentBase
     public override SegmentBase FromEntity(MessageChain chain, IMessageEntity entity)
     {
         if (entity is not ForwardEntity forward || Database is null) throw new ArgumentException("The entity is not a forward entity.");
-        
+
         var collection = Database.GetCollection<MessageRecord>();
-        
+
         int hash = MessageRecord.CalcMessageHash(forward.MessageId, forward.Sequence);
         var query = collection.FindById(hash);
         return query == null


### PR DESCRIPTION
- New API: GetC2CMessage; Retrieve historical messages through the sequence of private chat messages

- Fix #272; However, the private messages sent by the bot have not been stored in the database, only the error of Reply Id being 0 has been fixed, and now the correct message id will be displayed

- Fix the issue where replies to private messages cannot locate the original message