### PR TITLE
[Core]Recall the group message by sequence.

### DIFF
--- a/Lagrange.Core/Common/Interface/Api/OperationExt.cs
+++ b/Lagrange.Core/Common/Interface/Api/OperationExt.cs
@@ -69,7 +69,17 @@ public static class OperationExt
     /// <returns>Successfully recalled or not</returns>
     public static Task<bool> RecallGroupMessage(this BotContext bot, MessageChain chain)
         => bot.ContextCollection.Business.OperationLogic.RecallGroupMessage(chain);
-    
+
+    /// <summary>
+    /// Recall the group message by sequence
+    /// </summary>
+    /// <param name="bot">target BotContext</param>
+    /// <param name="groupUin">The uin for target group of the message</param>
+    /// <param name="sequence">The sequence for target message</param>
+    /// <returns>Successfully recalled or not</returns>
+    public static Task<bool> RecallGroupMessage(this BotContext bot, uint groupUin, uint sequence)
+        => bot.ContextCollection.Business.OperationLogic.RecallGroupMessage(groupUin, sequence);
+
     /// <summary>
     /// Recall the group message from Bot itself by <see cref="MessageResult"/>
     /// </summary>

--- a/Lagrange.Core/Internal/Context/Logic/Implementation/OperationLogic.cs
+++ b/Lagrange.Core/Internal/Context/Logic/Implementation/OperationLogic.cs
@@ -255,7 +255,14 @@ internal class OperationLogic : LogicBase
         var events = await Collection.Business.SendEvent(recallMessageEvent);
         return events.Count != 0 && ((RecallGroupMessageEvent)events[0]).ResultCode == 0;
     }
-    
+
+    public async Task<bool> RecallGroupMessage(uint groupUin, uint sequence)
+    {
+        var recallMessageEvent = RecallGroupMessageEvent.Create(groupUin, sequence);
+        var events = await Collection.Business.SendEvent(recallMessageEvent);
+        return events.Count != 0 && ((RecallGroupMessageEvent)events[0]).ResultCode == 0;
+    }
+
     public async Task<bool> RecallFriendMessage(uint friendUin, MessageResult result)
     {
         if (result.Sequence == null) return false;


### PR DESCRIPTION
When using only Lagrange.Core, the Sequence member of MessageResult has its set accessor marked as internal, making it impossible to recall messages using only Sequence. Therefore, I have added an API that allows message recall by Sequence.