### PR TITLE
[Core] Fix only the first message in the forwarded message has an image url

### DIFF
--- a/Lagrange.Core/Internal/Context/Logic/Implementation/MessagingLogic.cs
+++ b/Lagrange.Core/Internal/Context/Logic/Implementation/MessagingLogic.cs
@@ -217,7 +217,7 @@ internal class MessagingLogic : LogicBase
                 {
                     foreach (var chain in multi.Chains)
                     {
-                        if (chain.Count == 0) return;
+                        if (chain.Count == 0) continue;
                         await ResolveIncomingChain(chain);
                     }
                 }


### PR DESCRIPTION
The missing image URL in #594 is due to this issue