### PR TITLE
[All] add support for custom `BotAppInfo`

### DIFF
--- a/Lagrange.Core/BotContext.cs
+++ b/Lagrange.Core/BotContext.cs
@@ -24,13 +24,13 @@ public class BotContext : IDisposable
 
     private readonly BotKeystore _keystore;
 
-    internal BotContext(BotConfig config, BotDeviceInfo deviceInfo, BotKeystore keystore)
+    internal BotContext(BotConfig config, BotDeviceInfo deviceInfo, BotKeystore keystore, BotAppInfo appInfo)
     {
         Invoker = new EventInvoker(this);
         Scheduler = new Utility.TaskScheduler();
 
         Config = config;
-        AppInfo = BotAppInfo.ProtocolToAppInfo[config.Protocol];
+        AppInfo = appInfo;
         _deviceInfo = deviceInfo;
         _keystore = keystore;
 

--- a/Lagrange.Core/Common/BotAppInfo.cs
+++ b/Lagrange.Core/Common/BotAppInfo.cs
@@ -4,38 +4,38 @@ namespace Lagrange.Core.Common;
 
 public class BotAppInfo
 {
-    public string Os { get; private set; }
+    public string Os { get; set; }
     
-    public string VendorOs { get; private set; }
+    public string VendorOs { get; set; }
     
-    public string Kernel { get; private set; }
+    public string Kernel { get; set; }
 
-    public string CurrentVersion { get; private set; }
+    public string CurrentVersion { get; set; }
 
-    public int MiscBitmap { get; private set; }
+    public int MiscBitmap { get; set; }
     
-    public string PtVersion { get; private set; }
+    public string PtVersion { get; set; }
     
-    public int SsoVersion { get; private set; }
+    public int SsoVersion { get; set; }
     
-    public string PackageName { get; private set; }
+    public string PackageName { get; set; }
     
-    public string WtLoginSdk { get; private set; }
+    public string WtLoginSdk { get; set; }
 
-    public int AppId { get; private set; }
+    public int AppId { get; set; }
     
     /// <summary>Or known as pubId in tencent log</summary>
-    public int SubAppId { get; private set; }
+    public int SubAppId { get; set; }
     
-    public int AppIdQrCode { get; private set; }
+    public int AppIdQrCode { get; set; }
     
-    public ushort AppClientVersion { get; private set; }
+    public ushort AppClientVersion { get; set; }
     
-    public uint MainSigMap { get; private set; }
+    public uint MainSigMap { get; set; }
     
-    public ushort SubSigMap { get; private set; }
+    public ushort SubSigMap { get; set; }
     
-    public ushort NTLoginType { get; private set; }
+    public ushort NTLoginType { get; set; }
 
     private static readonly BotAppInfo Linux = new()
     {

--- a/Lagrange.Core/Common/Interface/BotFactory.cs
+++ b/Lagrange.Core/Common/Interface/BotFactory.cs
@@ -10,7 +10,18 @@ public static class BotFactory
     /// <param name="keystore">Existing Keystore from deserialization</param>
     /// <returns>Created BotContext Instance</returns>
     public static BotContext Create(BotConfig config, BotDeviceInfo deviceInfo, BotKeystore keystore) => 
-        new(config, deviceInfo, keystore);
+        new(config, deviceInfo, keystore, BotAppInfo.ProtocolToAppInfo[config.Protocol]);
+    
+    /// <summary>
+    /// Create new Bot from existing <see cref="BotKeystore"/> and <see cref="BotDeviceInfo"/> with custom <see cref="BotAppInfo"/>
+    /// </summary>
+    /// <param name="config">The config for Bot</param>
+    /// <param name="deviceInfo">Existing DeviceInfo from deserialization</param>
+    /// <param name="keystore">Existing Keystore from deserialization</param>
+    /// <param name="appInfo">Custom BotAppInfo, including client version, app ID, etc</param>
+    /// <returns></returns>
+    public static BotContext Create(BotConfig config, BotDeviceInfo deviceInfo, BotKeystore keystore, BotAppInfo appInfo) => 
+        new(config, deviceInfo, keystore, appInfo);
     
     /// <summary>
     /// Create new Bot from Password and uin
@@ -21,5 +32,17 @@ public static class BotFactory
     /// <param name="device">Created device, should be serialized to files for next use</param>
     /// <returns>Created BotContext Instance</returns>
     public static BotContext Create(BotConfig config, uint uin, string password, out BotDeviceInfo device) => 
-        new(config, device = BotDeviceInfo.GenerateInfo(), new BotKeystore(uin, password));
+        new(config, device = BotDeviceInfo.GenerateInfo(), new BotKeystore(uin, password), BotAppInfo.ProtocolToAppInfo[config.Protocol]);
+    
+    /// <summary>
+    /// Create new Bot from Password and uin with custom <see cref="BotAppInfo"/>
+    /// </summary>
+    /// <param name="config">The config for Bot</param>
+    /// <param name="uin">Uin, if QrCode login is used, ensure the account that scans QrCode is consistent with this Uin</param>
+    /// <param name="password">The password of account, for Password Login</param>
+    /// <param name="appInfo">Custom BotAppInfo, including client version, app ID, etc</param>
+    /// <param name="device">Created device, should be serialized to files for next use</param>
+    /// <returns></returns>
+    public static BotContext Create(BotConfig config, uint uin, string password, BotAppInfo appInfo, out BotDeviceInfo device) => 
+        new(config, device = BotDeviceInfo.GenerateInfo(), new BotKeystore(uin, password), appInfo);
 }

--- a/Lagrange.OneBot/LagrangeAppBuilder.cs
+++ b/Lagrange.OneBot/LagrangeAppBuilder.cs
@@ -86,7 +86,16 @@ public sealed class LagrangeAppBuilder
             deviceInfo = JsonSerializer.Deserialize<BotDeviceInfo>(File.ReadAllText(deviceInfoPath)) ?? BotDeviceInfo.GenerateInfo();
         }
 
-        Services.AddSingleton(BotFactory.Create(config, deviceInfo, keystore));
+        if (File.Exists("custom_appinfo.json"))
+        {
+            var appInfo = JsonSerializer.Deserialize<BotAppInfo>(File.ReadAllText("custom_appinfo.json"))!;
+            Console.WriteLine($"Using custom app info, version: {appInfo.CurrentVersion} @ {appInfo.Os}; App ID: {appInfo.SubAppId}");
+            Services.AddSingleton(BotFactory.Create(config, deviceInfo, keystore, appInfo));
+        }
+        else
+        {
+            Services.AddSingleton(BotFactory.Create(config, deviceInfo, keystore));
+        }
 
         return this;
     }


### PR DESCRIPTION
提供对自定义 `BotAppInfo` 的支持。具体更改如下：

- 在 Lagrange.Core 的 `BotFactory` 类中增加了两个包含 `BotAppInfo` 的静态方法；
- 在 Lagrange.OneBot 的初始化逻辑中增加了检测 `custom_appinfo.json` 是否存在的逻辑。若存在，则解析之，并将其中的 `BotAppInfo` 用于 `BotContext` 的初始化。

对原有的 API 及功能无影响。