### PR TITLE
[OneBot] Adjusting HTTP code to OneBot standards

### DIFF
--- a/Lagrange.OneBot/Core/Network/Service/HttpService.cs
+++ b/Lagrange.OneBot/Core/Network/Service/HttpService.cs
@@ -128,7 +128,7 @@ public sealed partial class HttpService(
                     if (!MediaTypeHeaderValue.TryParse(request.ContentType, out var mediaType))
                     {
                         Log.LogCannotParseMediaType(_logger, request.ContentType ?? string.Empty);
-                        response.StatusCode = (int)HttpStatusCode.UnsupportedMediaType;
+                        response.StatusCode = (int)HttpStatusCode.NotAcceptable;
                         response.Close();
                         return;
                     }


### PR DESCRIPTION
https://github.com/botuniverse/onebot-11/blob/d4456ee706f9ada9c2dfde56a2bcfc69752600e4/communication/http.md?plain=1#L41

所有的POST content-type不支持都应该返回406，所以哪怕遇到lgr无法处理的，也应该返回406