### PR TITLE
Fix 'System.PlatformNotSupportedException'

### DIFF
--- a/Lagrange.Core/Utility/Network/Icmp.cs
+++ b/Lagrange.Core/Utility/Network/Icmp.cs
@@ -6,8 +6,15 @@ internal static class Icmp
 {
     public static async Task<long> PingAsync(Uri hostIp, int timeout = 1000)
     {
-        using var ping = new Ping();
-        var reply = await ping.SendPingAsync(hostIp.Host, timeout);
-        return reply?.RoundtripTime ?? long.MaxValue;
+        try
+        {
+            using var ping = new Ping();
+            var reply = await ping.SendPingAsync(hostIp.Host, timeout);
+            return reply?.RoundtripTime ?? long.MaxValue;
+        }
+        catch (PlatformNotSupportedException)
+        {
+            return long.MaxValue;
+        }
     }
 }


### PR DESCRIPTION
Under some special OS env (such as docker container), may throw exception below:

```
Unhandled exception. System.PlatformNotSupportedException: The system's ping utility could not be found.
   at System.Net.NetworkInformation.Ping.GetPingProcess(IPAddress address, Byte[] buffer, Int32 timeout, PingOptions options)
   at System.Net.NetworkInformation.Ping.SendWithPingUtilityAsync(IPAddress address, Byte[] buffer, Int32 timeout, PingOptions options)
   at System.Net.NetworkInformation.Ping.SendPingAsyncInternal[TArg](TArg getAddressArg, Func`3 getAddress, Int32 timeout, Byte[] buffer, PingOptions options, CancellationToken cancellationToken)
   at Lagrange.Core.Utility.Network.Icmp.PingAsync(Uri hostIp, Int32 timeout)
   at Lagrange.Core.Internal.Context.SocketContext.OptimumServer(Boolean requestMsf, Boolean useIPv6Network)
   at Lagrange.Core.Internal.Context.SocketContext.Connect()
```

This PR adding try catch to ensuring that application can continue running without crashing.