### PR TITLE
更改 Tea 算法为托管算法

### DIFF
--- a/Lagrange.Core/Common/Interface/Api/GroupExt.cs
+++ b/Lagrange.Core/Common/Interface/Api/GroupExt.cs
@@ -88,7 +88,7 @@ public static class GroupExt
     public static Task<bool> SetGroupFilteredRequest(this BotContext bot, BotGroupRequest request, bool accept = true, string reason = "")
         => bot.ContextCollection.Business.OperationLogic.SetGroupFilteredRequest(request.GroupUin, request.Sequence, (uint)request.EventType, accept, reason);
 
-    public static Task<bool> SetFriendRequest(this BotContext bot, FriendRequestEvent request, bool accept = true)
+    public static Task<bool> SetFriendRequest(this BotContext bot, BotFriendRequest request, bool accept = true)
         => bot.ContextCollection.Business.OperationLogic.SetFriendRequest(request.SourceUid, accept);
 
     public static Task<bool> GroupPoke(this BotContext bot, uint groupUin, uint friendUin)

--- a/Lagrange.Core/Utility/Crypto/Provider/Tea/TeaProvider.cs
+++ b/Lagrange.Core/Utility/Crypto/Provider/Tea/TeaProvider.cs
@@ -2,104 +2,122 @@ using System.Runtime.CompilerServices;
 
 namespace Lagrange.Core.Utility.Crypto.Provider.Tea;
 
-internal static unsafe class TeaProvider
+internal static class TeaProvider
 {
-    private const long Delta = 2654435769L; // 0x9E3779B9, Fibonacci's hashing constant.
-    
+    private const uint Delta = 0x9E3779B9; // 0x9E3779B9, Fibonacci's hashing constant.
+
     private const long SumMax = (Delta << 4) & uint.MaxValue; // 0x9E3779B9 * 16 = 0x3C6EF35F, max sum value.
 
-    public static byte[] Encrypt(Span<byte> data, Span<byte> key)
+    public static byte[] Encrypt(ReadOnlySpan<byte> data, ReadOnlySpan<byte> key)
     {
         var keyStruct = new Key(key);
         int inputLength = data.Length;
         int fill = ((8 - ((inputLength + 10) & 7)) & 7) + 2;
         int length = fill + inputLength + 8;
-        
         var cipher = new byte[length];
         cipher[0] = (byte)(RandomByte(248) | (fill - 2));
-        for (int i = 1; i <= fill; ++i) cipher[i] = RandomByte();
-        
-        fixed (byte* dataPtr = cipher, rawPtr = data)
+
+        for (int i = 1; i <= fill; ++i)
         {
-            Buffer.MemoryCopy(rawPtr, dataPtr + fill + 1, inputLength, inputLength);
-
-            byte* plainXorPrev = stackalloc byte[8];
-            byte* tempCipher = stackalloc byte[8];
-            byte* plainXor = stackalloc byte[8];
-            byte* encipher = stackalloc byte[8];
-
-            for (int i = 0; i < length; i += 8)
-            {
-                *(long*)plainXor = *(long*)(dataPtr + i) ^ *(long*)(tempCipher);
-
-                long sum = 0;
-                long y = ReadUInt32(plainXor, 0);
-                long z = ReadUInt32(plainXor, 4);
-                for (int j = 0; j < 16; ++j)
-                {
-                    sum += Delta;
-                    sum &= uint.MaxValue;
-                    y += ((z << 4) + keyStruct.A) ^ (z + sum) ^ ((z >> 5) + keyStruct.B);
-                    y &= uint.MaxValue;
-                    z += ((y << 4) + keyStruct.C) ^ (y + sum) ^ ((y >> 5) + keyStruct.D);
-                    z &= uint.MaxValue;
-                }
-                
-                WriteUInt32(encipher, 0, (uint)y);
-                WriteUInt32(encipher, 4, (uint)z);
-                
-                *(long*)tempCipher = *(long*)(encipher) ^ *(long*)(plainXorPrev); // Xor8(EnCipher(plainXor, key), plainXorPrev);
-                *(long*)(plainXorPrev) = *(long*)(plainXor); // write data back to plainXorPrev
-                
-                *(long*)(dataPtr + i) = *(long*)(tempCipher); // write data back to cipher
-            }
+            cipher[i] = RandomByte();
         }
-        
+
+        // Copy input data to the cipher buffer
+        data.CopyTo(cipher.AsSpan(fill + 1));
+
+        Span<byte> plainXorPrev = stackalloc byte[8];
+        Span<byte> tempCipher = stackalloc byte[8];
+        Span<byte> plainXor = stackalloc byte[8];
+        Span<byte> encipher = stackalloc byte[8];
+
+        for (int i = 0; i < length; i += 8)
+        {
+            // XOR current block with the previous cipher block
+            for (int j = 0; j < 8; j++)
+            {
+                plainXor[j] = (byte)(cipher[i + j] ^ tempCipher[j]);
+            }
+
+            // Perform TEA encryption
+            uint y = ReadUInt32(plainXor, 0);
+            uint z = ReadUInt32(plainXor, 4);
+            uint sum = 0;
+
+            for (int j = 0; j < 16; ++j)
+            {
+                sum += Delta;
+                y += ((z << 4) + keyStruct.A) ^ (z + sum) ^ ((z >> 5) + keyStruct.B);
+                z += ((y << 4) + keyStruct.C) ^ (y + sum) ^ ((y >> 5) + keyStruct.D);
+            }
+
+            WriteUInt32(encipher, 0, y);
+            WriteUInt32(encipher, 4, z);
+
+            // XOR the encrypted block with the previous plain block
+            for (int j = 0; j < 8; j++)
+            {
+                tempCipher[j] = (byte)(encipher[j] ^ plainXorPrev[j]);
+            }
+
+            // Copy the current plain block to plainXorPrev
+            plainXor.CopyTo(plainXorPrev);
+
+            // Write the encrypted block back to the cipher array
+            tempCipher.CopyTo(cipher.AsSpan(i, 8));
+        }
+
         return cipher;
     }
-
     public static byte[] Decrypt(Span<byte> data, Span<byte> key)
     {
         var keyStruct = new Key(key);
         int length = data.Length;
-        if ((length & 7) != 0 || (length >> 4) == 0) throw new Exception("Invalid cipher data length.");
-        
-        var plain = new byte[length];
-        byte* plainSub = stackalloc byte[8];
-        byte* plainXor = stackalloc byte[8];
-
-        fixed (byte* rawPtr = data, dataPtr = plain)
+        if ((length & 7) != 0 || (length >> 4) == 0)
         {
-            for (int i = 0; i < length; i += 8) // Decrypt data.
-            {
-                *(long*)plainXor = *(long*)(rawPtr + i) ^ *(long*)(plainSub);
-                
-                long sum = SumMax;
-                long y = ReadUInt32(plainXor, 0);
-                long z = ReadUInt32(plainXor, 4);
-                for (int j = 0; j < 16; ++j)
-                {
-                    z -= ((y << 4) + keyStruct.C) ^ (y + sum) ^ ((y >> 5) + keyStruct.D);
-                    z &= uint.MaxValue;
-                    y -= ((z << 4) + keyStruct.A) ^ (z + sum) ^ ((z >> 5) + keyStruct.B);
-                    y &= uint.MaxValue;
-                    sum -= Delta;
-                    sum &= uint.MaxValue;
-                }
-                
-                WriteUInt32(plainSub, 0, (uint)y);
-                WriteUInt32(plainSub, 4, (uint)z);
-                
-                *(long*)(dataPtr + i) = *(long*)(plainSub) ^ *(long*)(rawPtr + i - 8);
-            }
-            
-            for (int i = length - 7; i < length; ++i) // Verify that the last 7 bytes are 0.
-            {
-                if (plain[i] != 0) throw new Exception("Verification failed.");
-            }
-            int from = (plain[0] & 7) + 3;  // Extract valid data.
-            return plain[from..(length - 7)];
+            throw new Exception("Invalid cipher data length.");
         }
+
+        var plain = new byte[length];
+        var plainSub = new byte[8];
+        var plainXor = new byte[8];
+
+        for (int i = 0; i < length; i += 8)
+        {
+            for (int j = 0; j < 8; j++)
+            {
+                plainXor[j] = (byte)(data[i + j] ^ plainSub[j]);
+            }
+
+            long sum = SumMax;
+            uint y = ReadUInt32(plainXor, 0);
+            uint z = ReadUInt32(plainXor, 4);
+
+            for (int j = 0; j < 16; ++j)
+            {
+                z -= (uint)(((y << 4) + keyStruct.C) ^ (y + sum) ^ ((y >> 5) + keyStruct.D));
+                y -= (uint)(((z << 4) + keyStruct.A) ^ (z + sum) ^ ((z >> 5) + keyStruct.B));
+                sum -= Delta;
+            }
+
+            WriteUInt32(plainSub, 0, y);
+            WriteUInt32(plainSub, 4, z);
+
+            for (int j = 0; j < 8; j++)
+            {
+                plain[i + j] = (byte)(plainSub[j] ^ (i >= 8 ? data[i + j - 8] : 0));
+            }
+        }
+
+        for (int i = length - 7; i < length; ++i)
+        {
+            if (plain[i] != 0)
+            {
+                throw new Exception("Verification failed.");
+            }
+        }
+
+        int from = (plain[0] & 7) + 3;
+        return plain[from..(length - 7)];
     }
 
     private readonly struct Key
@@ -109,30 +127,34 @@ internal static unsafe class TeaProvider
         public uint C { get; }
         public uint D { get; }
 
-        public Key(Span<byte> rawKey)
+        public Key(ReadOnlySpan<byte> rawKey)
         {
-            fixed (byte* rawKeyPtr = rawKey)
+            if (rawKey.Length < 16)
             {
-                A = ReadUInt32(rawKeyPtr, 0);
-                B = ReadUInt32(rawKeyPtr, 4);
-                C = ReadUInt32(rawKeyPtr, 8);
-                D = ReadUInt32(rawKeyPtr, 12);
+                throw new ArgumentException("Key must be at least 16 bytes long.", nameof(rawKey));
             }
+
+            A = ReadUInt32(rawKey, 0);
+            B = ReadUInt32(rawKey, 4);
+            C = ReadUInt32(rawKey, 8);
+            D = ReadUInt32(rawKey, 12);
         }
     }
-    
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static uint ReadUInt32(byte* data, int index) => (uint)(data[index] << 24 | data[index + 1] << 16 | data[index + 2] << 8 | data[index + 3]);
-
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static void WriteUInt32(byte* data, int index, uint value)
+    private static uint ReadUInt32(ReadOnlySpan<byte> data, int offset)
     {
-        data[index] = (byte)(value >> 24);
-        data[index + 1] = (byte)(value >> 16);
-        data[index + 2] = (byte)(value >> 8);
-        data[index + 3] = (byte)value;
+        return (uint)((data[offset] << 24) |
+                      (data[offset + 1] << 16) |
+                      (data[offset + 2] << 8) |
+                      data[offset + 3]);
     }
 
-    [MethodImpl(MethodImplOptions.AggressiveInlining)]
-    private static byte RandomByte(int max = byte.MaxValue) => (byte) (Random.Shared.Next() & max);
+    private static void WriteUInt32(Span<byte> data, int offset, uint value)
+    {
+        data[offset] = (byte)((value >> 24) & 0xFF);
+        data[offset + 1] = (byte)((value >> 16) & 0xFF);
+        data[offset + 2] = (byte)((value >> 8) & 0xFF);
+        data[offset + 3] = (byte)(value & 0xFF);
+    }
+
+    private static byte RandomByte(int max = byte.MaxValue) => (byte)(Random.Shared.Next() & max);
 }


### PR DESCRIPTION
相关issue: #444

在尝试将 Lagrange.Core 集成到一个独立项目时，我参考了 Lagrange.Onebot 的登录逻辑。然而，每次在拉取二维码时，都会遇到 Issue #444 中描述的问题。

由于我的项目需要设置为 x86 运行时，而 Issue 中提到的问题发生在 Arm 环境下，我推测两者可能存在相似性。

经过代码跟踪，我发现问题的根源可能在[PacketContext.cs#L91](https://github.com/Hellobaka/Lagrange.Core/blob/6792a454cf54387164da9856848db788da5e4658/Lagrange.Core/Internal/Context/PacketContext.cs?plain=1#L91)中。同样运行到此行时，AnyCPU 不会异常，但是 x86 会异常。

进一步分析后，我认为问题出在 Tea 算法的 unsafe 实现。由于我对 Tea 算法的具体实现不了解，所以不能直接修改 unsafe 的算法。我借助了 ChatGPT 对其进行了修改，并完成了一个托管实现。

经过一些密文的测试，能够与 unsafe 算法进行互相转换。而且在x86的环境下，拉取二维码也不会出现 Issue 中的问题
```
Raw: 48656C6C6F2C20576F726C6421
Unsafe_Encrypt: 985D4A9D65627C8C29061244790EC6319CD2EF6FE1C7DC92
Unsafe_Decrypt: 48656C6C6F2C20576F726C6421
-----
Raw: 48656C6C6F2C20576F726C6421
Safe_Encrypt: 9BC5EB1DAB8C031844EDF1B11B4CF151E9DBEA51EF3D8C14
Safe_Decrypt: 48656C6C6F2C20576F726C6421
Unsafe_Decrypt: 48656C6C6F2C20576F726C6421
```
![image](https://github.com/user-attachments/assets/acc7922e-0166-41bd-82d1-b103d0c11a28)
![image](https://github.com/user-attachments/assets/93d5193e-6090-42ec-ba72-74edffeeb3c2)
