### PR TITLE
[OneBot] 添加戳一戳二合一接口

### DIFF
--- a/Lagrange.OneBot/Core/Entity/Action/OneBotSendPoke.cs
+++ b/Lagrange.OneBot/Core/Entity/Action/OneBotSendPoke.cs
@@ -1,0 +1,11 @@
+using System.Text.Json.Serialization;
+
+namespace Lagrange.OneBot.Core.Entity.Action;
+
+[Serializable]
+public class OneBotSendPoke
+{
+    [JsonPropertyName("user_id")] public uint UserId { get; set; }
+    
+    [JsonPropertyName("group_id")] public uint? GroupId { get; set; }
+}

--- a/Lagrange.OneBot/Core/Operation/Message/SendPokeOperation.cs
+++ b/Lagrange.OneBot/Core/Operation/Message/SendPokeOperation.cs
@@ -1,0 +1,31 @@
+using System.Text.Json;
+using System.Text.Json.Nodes;
+using Lagrange.Core;
+using Lagrange.Core.Common.Interface.Api;
+using Lagrange.OneBot.Core.Entity.Action;
+using Lagrange.OneBot.Core.Operation.Converters;
+
+namespace Lagrange.OneBot.Core.Operation.Message;
+
+[Operation("send_poke")]
+public class SendPokeOperation : IOperation
+{
+    public async Task<OneBotResult> HandleOperation(BotContext context, JsonNode? payload)
+    {
+        if (payload.Deserialize<OneBotSendPoke>(SerializerOptions.DefaultOptions) is { } poke)
+        {
+            if (poke.GroupId == null)
+            {
+                bool result = await context.FriendPoke(poke.UserId);
+                return new OneBotResult(null, result ? 0 : 1, result ? "ok" : "failed");
+            }
+            else
+            {
+                bool result = await context.GroupPoke(poke.GroupId.Value, poke.UserId);
+                return new OneBotResult(null, result ? 0 : 1, result ? "ok" : "failed");
+            }
+        }
+
+        throw new Exception();
+    }
+}


### PR DESCRIPTION
`send_poke`
传入group_id按group_poke处理,
否则按friend_poke处理