### PR TITLE
[OneBot]: 修复数据库不记录文件消息

### DIFF
--- a/Lagrange.OneBot/Database/MessageEntityResolver.cs
+++ b/Lagrange.OneBot/Database/MessageEntityResolver.cs
@@ -8,10 +8,12 @@ public class MessageEntityResolver : IFormatterResolver
 {
     private static readonly MessageEntityFormatter _FORMATTER = new();
 
+    private static readonly StreamFormatter _STREAM_FORMATTER = new();
+
     public IMessagePackFormatter<T>? GetFormatter<T>()
     {
         if (typeof(T) == typeof(IMessageEntity)) return (IMessagePackFormatter<T>?)_FORMATTER;
-
+        if (typeof(T) == typeof(Stream)) return (IMessagePackFormatter<T>?)_STREAM_FORMATTER;
         return null;
     }
 }

--- a/Lagrange.OneBot/Database/MessageRecord.cs
+++ b/Lagrange.OneBot/Database/MessageRecord.cs
@@ -31,6 +31,7 @@ public partial class MessageRecord : IRealmObject
     public static readonly MessagePackSerializerOptions OPTIONS = MessagePackSerializerOptions.Standard
         .WithResolver(CompositeResolver.Create(
             ContractlessStandardResolver.Instance,
+            ContractlessStandardResolverAllowPrivate.Instance,
             new MessageEntityResolver()
         ));
 

--- a/Lagrange.OneBot/Database/StreamFormatter.cs
+++ b/Lagrange.OneBot/Database/StreamFormatter.cs
@@ -1,0 +1,33 @@
+using MessagePack;
+using MessagePack.Formatters;
+using System.Buffers;
+
+namespace Lagrange.OneBot.Database;
+
+public class StreamFormatter : IMessagePackFormatter<Stream?>
+{
+    public void Serialize(ref MessagePackWriter writer, Stream? value, MessagePackSerializerOptions options)
+    {
+        if (value == null)
+        {
+            writer.WriteNil();
+            return;
+        }
+        byte[] buffer = new byte[value.Length];
+        value.ReadExactly(buffer);
+        writer.Write(buffer);
+    }
+
+    public Stream? Deserialize(ref MessagePackReader reader, MessagePackSerializerOptions options)
+    {
+        if (reader.TryReadNil())
+            return null;
+        var sequence = reader.ReadBytes();
+        if (sequence.HasValue)
+        {
+            byte[] buffer = sequence.Value.ToArray();
+            return new MemoryStream(buffer);
+        }
+        return null;
+    }
+}


### PR DESCRIPTION
因为FileEntity 某些属性 setter是Internal的，MessagePackSerializer反序列化不会设置这些属性值，此pr修复该问题