### PR TITLE
[Core] Fix the parsing of group invitation event

### DIFF
--- a/Lagrange.Core/Internal/Context/Logic/Implementation/MessagingLogic.cs
+++ b/Lagrange.Core/Internal/Context/Logic/Implementation/MessagingLogic.cs
@@ -71,13 +71,16 @@ internal class MessagingLogic : LogicBase
                 var chain = push.Chain;
 
                 // Intercept group invitation
-                if (chain.Count == 1 && chain[0] is LightAppEntity { AppName: "com.tencent.qun.invite" } app)
+                if (chain.Count == 1 && chain[0] is LightAppEntity
+                    {
+                        AppName: "com.tencent.qun.invite" or "com.tencent.tuwen.lua"
+                    } app)
                 {
                     using var document = JsonDocument.Parse(app.Payload);
                     var root = document.RootElement;
 
                     string url = root.GetProperty("meta").GetProperty("news").GetProperty("jumpUrl").GetString()
-                        ?? throw new Exception("sb tx! Is this 'com.tencent.qun.invite'?");
+                        ?? throw new Exception("sb tx! Is this 'com.tencent.qun.invite' or 'com.tencent.tuwen.lua'?");
                     var query = HttpUtility.ParseQueryString(new Uri(url).Query);
                     uint groupUin = uint.Parse(query["groupcode"]
                         ?? throw new Exception("sb tx! Is this '/group/invite_join'?"));


### PR DESCRIPTION
现在QQ好友邀请加群的卡片推送的 AppName 叫 com.tencent.tuwen.lua，结构不变，出于兼容性保留了之前的 AppName com.tencent.qun.invite