### PR TITLE
[Core] Fix a bug in the LightAppEntity Build function to support send…

### DIFF
--- a/Lagrange.Core/Message/Entities/LightAppEntity.cs
+++ b/Lagrange.Core/Message/Entities/LightAppEntity.cs
@@ -23,9 +23,10 @@ public class LightAppEntity : IMessageEntity
     
     Elem[] IMessageEntity.Build()
     {
-        using var payload = new BinaryPacket();
+        var compressed = ZCompression.ZCompress(Encoding.UTF8.GetBytes(Payload));
+        using var payload = new BinaryPacket(1 + compressed.Length);
         payload.Write<byte>(0x01);
-        payload.Write(ZCompression.ZCompress(Encoding.UTF8.GetBytes(Payload)));
+        payload.Write(compressed);
 
         return new Elem[]
         {

--- a/Lagrange.Core/Message/MessageBuilder.cs
+++ b/Lagrange.Core/Message/MessageBuilder.cs
@@ -93,7 +93,13 @@ public class MessageBuilder
         _entities.Add(new VideoEntity(video, thumbnail, disposeOnCompletion));
         return this;
     }
-    
+
+    public MessageBuilder LightApp(string json)
+    {
+        _entities.Add(new LightAppEntity(json));
+        return this;
+    }
+
     public static MessageBuilder operator +(MessageBuilder builder, IMessageEntity entity)
     {
         builder._entities.Add(entity);


### PR DESCRIPTION
使用无参构造BinaryPacket时调用BinaryPacket.GrowSize函数会导致陷入死循环。
不清楚开发者意图是什么，或许应该禁用无参构造。
```
internal ref struct BinaryPacket
{
    private int _offset;
    private int _capacity;
    private void GrowSize(int additional)
    {
        while (_offset + additional > _capacity) _capacity *= 2; //_capacity 初始值为 0 时， 0 * 2 = 0 恒成立，条件是死循环。
        _bytesToReturnToPool = ArrayPool<byte>.Shared.Rent(_capacity);

        _span[.._offset].CopyTo(_bytesToReturnToPool.AsSpan());

        _span = _bytesToReturnToPool.AsSpan();
        _buffer = ref Unsafe.Add(ref MemoryMarshal.GetReference(_span), _offset);
    }
}
```