### PR TITLE
[Core] Fix the issues in BinaryPacket.GrowSize

### DIFF
--- a/Lagrange.Core/Utility/Binary/BinaryPacket.cs
+++ b/Lagrange.Core/Utility/Binary/BinaryPacket.cs
@@ -292,12 +292,17 @@ internal ref struct BinaryPacket
     [MethodImpl(MethodImplOptions.NoInlining)] // NoInlining is used to prevent the method from being inlined as it is not used frequently
     private void GrowSize(int additional)
     {
-        while (_offset + additional > _capacity) _capacity *= 2;
-        _bytesToReturnToPool = ArrayPool<byte>.Shared.Rent(_capacity);
+        int requested = _offset + additional;
+        int desired = (int)BitOperations.RoundUpToPowerOf2((uint)requested);
+        int capacity = desired > requested ? desired : requested;
 
-        _span[.._offset].CopyTo(_bytesToReturnToPool.AsSpan());
+        var rent = ArrayPool<byte>.Shared.Rent(capacity);
+        _span[.._offset].CopyTo(rent.AsSpan());
+        if (_bytesToReturnToPool != null) ArrayPool<byte>.Shared.Return(_bytesToReturnToPool);
+        _capacity = capacity;
+        _bytesToReturnToPool = rent;
 
-        _span = _bytesToReturnToPool.AsSpan();
+        _span = rent.AsSpan();
         _buffer = ref Unsafe.Add(ref MemoryMarshal.GetReference(_span), _offset);
     }
     


### PR DESCRIPTION
Fix the issue where BinaryPacket.GrowSize enters an infinite loop and fails to return the shared buffer.

> 使用无参构造BinaryPacket时调用BinaryPacket.GrowSize函数会导致陷入死循环。
不清楚开发者意图是什么，或许应该禁用无参构造。

@Controllerdestiny 没有方法能够禁止调用结构体的默认构造, 总是能通过 `default(T)` 创建数据全零的结构体
顺带修复扩容时有借无还的问题

~~扩容算法摘自 `Hacker’s Delight 2nd edition, Chapter 3. Power-of-2 Boundaries, 3–2 Rounding Up/Down to the Next Power of 2`~~
原来BCL给了 `BitOperations.RoundUpToPowerOf2`