### PR TITLE
fix: refresh friend and group lists on cache miss

### DIFF
--- a/Lagrange.Core/Internal/Context/CacheContext.cs
+++ b/Lagrange.Core/Internal/Context/CacheContext.cs
@@ -60,7 +60,7 @@ internal class CacheContext(BotContext context)
 
         if (friend == null)
         {
-            _friends = Interlocked.Exchange(ref _friends, await FetchFriends());
+            Interlocked.Exchange(ref _friends, await FetchFriends());
             friend = _friends?.FirstOrDefault(f => f.Uin == uin);
         }
 
@@ -87,7 +87,7 @@ internal class CacheContext(BotContext context)
 
         if (group == null)
         {
-            _groups = Interlocked.Exchange(ref _groups, await FetchGroups());
+            Interlocked.Exchange(ref _groups, await FetchGroups());
             group = _groups?.FirstOrDefault(f => f.GroupUin == groupUin);
         }
 


### PR DESCRIPTION
修复群聊和好友列表不刷新的问题
直接导致 Bot 加入新群后直接报错, 无法接受新群消息