### PR TITLE
[Core] Add group member mute support

### DIFF
--- a/Lagrange.Core/Common/Interface/MessageExt.cs
+++ b/Lagrange.Core/Common/Interface/MessageExt.cs
@@ -99,6 +99,9 @@ public static class MessageExt
     public static Task<bool> MuteGroupGlobal(this BotContext context, long groupUin, bool isMute)
         => context.EventContext.GetLogic<OperationLogic>().MuteGroupGlobal(groupUin, isMute);
 
+    public static Task<bool> MuteGroupMember(this BotContext context, long groupUin, long targetUin, uint duration)
+        => context.EventContext.GetLogic<OperationLogic>().MuteGroupMember(groupUin, targetUin, duration);
+
     public static Task<bool> GroupTransfer(this BotContext context, long groupUin, long targetUin)
         => context.EventContext.GetLogic<OperationLogic>().GroupTransfer(groupUin, targetUin);
 

--- a/Lagrange.Core/Internal/Events/System/GroupMuteMemberEvent.cs
+++ b/Lagrange.Core/Internal/Events/System/GroupMuteMemberEvent.cs
@@ -1,0 +1,17 @@
+using Lagrange.Core.Events;
+
+namespace Lagrange.Core.Internal.Events.System;
+
+internal class GroupMuteMemberEventReq(long groupUin, string targetUid, uint duration) : ProtocolEvent
+{
+    public long GroupUin { get; } = groupUin;
+
+    public string TargetUid { get; } = targetUid;
+
+    public uint Duration { get; } = duration;
+}
+
+internal class GroupMuteMemberEventResp : ProtocolEvent
+{
+    public static readonly GroupMuteMemberEventResp Default = new();
+}

--- a/Lagrange.Core/Internal/Logic/OperationLogic.cs
+++ b/Lagrange.Core/Internal/Logic/OperationLogic.cs
@@ -88,6 +88,20 @@ internal class OperationLogic(BotContext context) : ILogic
         return true;
     }
 
+    public async Task<bool> MuteGroupMember(long groupUin, long targetUin, uint duration)
+    {
+        if (context.CacheContext.ResolveCachedUid(targetUin) is not { } uid)
+        {
+            await context.CacheContext.GetMemberList(groupUin, true);
+            uid = context.CacheContext.ResolveCachedUid(targetUin);
+        }
+
+        if (uid == null) return false;
+
+        await context.EventContext.SendEvent<GroupMuteMemberEventResp>(new GroupMuteMemberEventReq(groupUin, uid, duration));
+        return true;
+    }
+
     public async Task<bool> GroupTransfer(long groupUin, long targetUin)
     {
         await context.EventContext.SendEvent<GroupTransferEventResp>(new GroupTransferEventReq(groupUin, targetUin));

--- a/Lagrange.Core/Internal/Packets/Service/Oidb_0x1253.cs
+++ b/Lagrange.Core/Internal/Packets/Service/Oidb_0x1253.cs
@@ -1,0 +1,29 @@
+using Lagrange.Proto;
+
+namespace Lagrange.Core.Internal.Packets.Service;
+
+#pragma warning disable CS8618
+
+[ProtoPackable]
+internal partial class D1253ReqBody
+{
+    [ProtoPackable]
+    internal partial class MuteInfo
+    {
+        [ProtoMember(1)] public string TargetUid { get; set; }
+
+        [ProtoMember(2)] public uint Duration { get; set; }
+    }
+
+    [ProtoMember(1)] public uint GroupUin { get; set; }
+
+    [ProtoMember(2)] public uint Type { get; set; }
+
+    [ProtoMember(3)] public MuteInfo Body { get; set; }
+}
+
+[ProtoPackable]
+internal partial class D1253RspBody
+{
+    [ProtoMember(2)] public string? Success { get; set; }
+}

--- a/Lagrange.Core/Internal/Services/System/GroupMuteMemberService.cs
+++ b/Lagrange.Core/Internal/Services/System/GroupMuteMemberService.cs
@@ -1,0 +1,32 @@
+using Lagrange.Core.Common;
+using Lagrange.Core.Internal.Events.System;
+using Lagrange.Core.Internal.Packets.Service;
+using Lagrange.Core.Services;
+
+namespace Lagrange.Core.Internal.Services.System;
+
+[EventSubscribe<GroupMuteMemberEventReq>(Protocols.All)]
+[Service("OidbSvcTrpcTcp.0x1253_1")]
+internal class GroupMuteMemberService : OidbService<GroupMuteMemberEventReq, GroupMuteMemberEventResp, D1253ReqBody, D1253RspBody>
+{
+    protected override uint Command => 0x1253;
+
+    protected override uint Service => 1;
+
+    protected override Task<D1253ReqBody> ProcessRequest(GroupMuteMemberEventReq request, BotContext context)
+    {
+        return Task.FromResult(new D1253ReqBody
+        {
+            GroupUin = checked((uint)request.GroupUin),
+            Type = 1,
+            Body = new D1253ReqBody.MuteInfo
+            {
+                TargetUid = request.TargetUid,
+                Duration = request.Duration
+            }
+        });
+    }
+
+    protected override Task<GroupMuteMemberEventResp> ProcessResponse(D1253RspBody response, BotContext context) =>
+        Task.FromResult(GroupMuteMemberEventResp.Default);
+}


### PR DESCRIPTION
This PR adds support for muting individual group members by exposing the MuteGroupMember API through MessageExt and implementing the corresponding operation event, service, and request packet using OidbSvcTrpcTcp.0x1253_1. 
The implementation has been successfully built for all target frameworks supported.